### PR TITLE
Enable sitemap and robots directives

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,6 @@
 title: .
 description: <_>
 theme: jekyll-theme-cayman
+
+plugins:
+  - jekyll-sitemap

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://<site-domain>/sitemap.xml


### PR DESCRIPTION
## Summary
- enable the `jekyll-sitemap` plugin in `_config.yml`
- add `robots.txt` for crawler instructions

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_b_686f6b4acdb4832da1be8f78bad207fc