### PR TITLE
Update favicon with neon Z design

### DIFF
--- a/assets/images/favicon.svg
+++ b/assets/images/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-  <rect width="16" height="16" rx="2" ry="2" fill="#157878"/>
-  <path d="M4 4h8L4 12h8" stroke="#fff" stroke-width="2" fill="none"/>
+  <circle cx="8" cy="8" r="8" fill="#111"/>
+  <path d="M4 4h8L4 12h8" stroke="#00ffff" stroke-width="2" fill="none" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
## Summary
- redesign favicon with circular dark background and neon Z

## Testing
- `python3 scripts/test_links.py`

------
https://chatgpt.com/codex/tasks/task_b_6889e77dd670832db907c4c7d3e0fbea