### PR TITLE
Add ASCII banner

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -35,3 +35,15 @@ img {
 .back-to-top.active {
   display: block;
 }
+
+.ascii-banner {
+  color: #39ff14;
+  text-shadow: 0 0 5px #39ff14;
+  font-family: monospace;
+}
+
+@media (max-width: 480px) {
+  .ascii-banner {
+    display: none;
+  }
+}

--- a/index.md
+++ b/index.md
@@ -3,6 +3,13 @@ layout: default
 title: About Me
 ---
 
+<pre class="ascii-banner">
+ ____  _   ___ _  __  ___  _____   __
+|_  / /_\ / __| |/ / |   \| __\ \ / /
+ / / / _ \ (__| ' <  | |) | _| \ V /
+/___/_/ \_\___|_|\_\ |___/|___| \_/
+</pre>
+
 # About Me
 
 I'm a Deep Learning and Computer Vision enthusiast passionate about building solutions spark curiosity and do some small usefull thing. You'll often find me engrossed in training neural networks or architecting AI agents capable of autonomously navigating Android UIs. Below is an overview of my journey, expertise, and some projects I've brought to life.


### PR DESCRIPTION
## Summary
- add small ASCII banner to the top of the About page
- style ASCII banner with neon green text and hide it on very small screens

## Testing
- `python3 scripts/test_links.py`

------
https://chatgpt.com/codex/tasks/task_b_6889e77c4644832d80939ca9b87e899e